### PR TITLE
Guard against unmounting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ export default function useMaxConcurrentFetch({
   
   useEffect(() => {
     if (shouldMakeNewRequest) {
+      let isOldRequest = false;
       const abortController = new AbortController();
       setInFlightRequests(abortController);
       if (inFlightRequests.length > max) {
@@ -23,14 +24,24 @@ export default function useMaxConcurrentFetch({
       }
       fetch(url, { signal: abortController.signal, ...options })
         .then(res => {
+          if (isOldRequest) {
+            return;
+          }
           const result = handleSuccess(res);
           setResult([...results, result]);
         })
         .catch(error => {
+          if (isOldRequest) {
+            return;
+          }
           const result = handleError(error);
           setReult([...results, result]);
         });
     }
+
+    return () => {
+      isOldRequest = true;
+    };
   }, [shouldMakeNewRequest]);
 
   return results;


### PR DESCRIPTION
A component can unmount by the time that the fetch resolves. In such a situation, the call to `setResult` would throw an error.

---

Note that this doesn't only guard against unmounting – it also guards against `shouldMakeNewRequest` changing – which is why I used the variable name `isOldRequest` rather than `isUnmounted`.
